### PR TITLE
refold-ease: graceful synchronisation support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -89,7 +89,13 @@ def notify(ez_factor_human: int):
 
 def resetEase(ez_factor_human: int = 250):
     ez_factor_anki = ez_factor_human * 10
-    mw.col.db.execute("update cards set factor = ?", ez_factor_anki)
+
+    card_ids = mw.col.db.list("SELECT id FROM cards WHERE factor != 0")
+    for card_id in card_ids:
+        card = mw.col.getCard(card_id)
+        if card.factor != ez_factor_anki:
+            card.factor = ez_factor_anki
+            card.flush()
 
 
 def adjustIM(new_ease: int, base_im: int = 100) -> int:


### PR DESCRIPTION
Currently this add-on changes card ease factors directly through `mw.col.db`.
This results in Anki not knowing that card properties have been changed,
which in turn requires a force-sync. Force-syncs are inconvenient and
it's simply much more efficient to use the recommended workflow for
modifying cards.

This is effectively an identical patch [to the one applied to ResetEase][1].

And since force-syncs are no longer required, remove the "force sync"
checkbox.

[1]: AnKingMed/Reset-Ease#4

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>