### PR TITLE
refold-ease: fix typing to not crash on startup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,8 @@ from aqt.utils import showInfo
 # import all of the Qt GUI library
 from aqt.qt import *
 
+from typing import List, Tuple
+
 """
 MattVsJapan Anki Reset Ease script
 
@@ -150,7 +152,7 @@ def updateGroups(deck_id: str, new_starting_ease: int, new_interval_modifier: in
         updateGroupSettings(dconf['id'])
 
 
-def getDecksInfo() -> list[tuple]:
+def getDecksInfo() -> List[Tuple]:
     result = []
     decks = mw.col.decks.all()
     for deck in decks:


### PR DESCRIPTION
list[tuple] is not the correct way of referencing the type, and causes
a TypeError when the add-on is loaded:

```
  When loading '⁨RefoldEase⁩':
  ⁨Traceback (most recent call last):
    File "aqt/addons.py", line 211, in loadAddons
    File "/home/cyphar/.local/share/Anki2/addons21/RefoldEase/__init__.py", line 153, in <module>
      def getDecksInfo() -> list[tuple]:
  TypeError: 'type' object is not subscriptable
```

The correct way is to import typing and use List[Tuple].

Fixes: 101bbe15a9c1 ("allow the user to limit change of ease factors to a selected deck")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>